### PR TITLE
Simplifications of the affine curve code to make use of the shape assumptions.

### DIFF
--- a/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
+++ b/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
@@ -141,11 +141,11 @@ public class DncTestMethodSources {
 		curves.add(AlgDncBackend_DNC_ConPwAffine.DISCO_CONPWAFFINE);
 		curves.add(AlgDncBackend_DNC_Affine.DISCO_AFFINE);
 
-		curves.add(AlgDncBackend_DNC_AffineC_PwAffineMP.DISCO_AFFINEC_PWAFFINEMP);
-		curves.add(AlgDncBackend_DNC_PwAffineC_AffineMP.DISCO_PWAFFINEC_AFFINEMP);
+		//curves.add(AlgDncBackend_DNC_AffineC_PwAffineMP.DISCO_AFFINEC_PWAFFINEMP);
+		//curves.add(AlgDncBackend_DNC_PwAffineC_AffineMP.DISCO_PWAFFINEC_AFFINEMP);
 		
 		curves.add(AlgDncBackend_MPARTC_PwAffine.MPARTC_PWAFFINE);
-		curves.add(AlgDncBackend_MPARTC_DISCO_Affine.MPARTC_PWAFFINEC_DISCO_AFFINEMP);
+		//curves.add(AlgDncBackend_MPARTC_DISCO_Affine.MPARTC_PWAFFINEC_DISCO_AFFINEMP);
 		curves.add(AlgDncBackend_MPARTC_DISCO_PwAffine.MPARTC_PWAFFINEC_DISCO_CONPWAFFINEMP);
 
 		// Parameter configurations for single arrival bounding tests:

--- a/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
+++ b/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
@@ -47,9 +47,7 @@ import org.networkcalculus.dnc.algebra.disco.con_pw_affine.MinPlus_Disco_ConPwAf
 import org.networkcalculus.dnc.curves.Curve;
 import org.networkcalculus.dnc.curves.LinearSegment;
 import org.networkcalculus.dnc.curves.disco.LinearSegment_Disco;
-import org.networkcalculus.dnc.curves.disco.affine.Curve_Disco_Affine;
 import org.networkcalculus.dnc.curves.disco.pw_affine.Curve_Disco_PwAffine;
-import org.networkcalculus.dnc.func_tests.AlgDncBackend_DNC_AffineC_PwAffineMP;
 import org.networkcalculus.dnc.func_tests.AlgDncBackend_DNC_PwAffineC_AffineMP;
 import org.networkcalculus.dnc.func_tests.DncTestConfig;
 import org.networkcalculus.num.NumBackend;
@@ -141,11 +139,10 @@ public class DncTestMethodSources {
 		curves.add(AlgDncBackend_DNC_ConPwAffine.DISCO_CONPWAFFINE);
 		curves.add(AlgDncBackend_DNC_Affine.DISCO_AFFINE);
 
-		//curves.add(AlgDncBackend_DNC_AffineC_PwAffineMP.DISCO_AFFINEC_PWAFFINEMP);
-		//curves.add(AlgDncBackend_DNC_PwAffineC_AffineMP.DISCO_PWAFFINEC_AFFINEMP);
+		curves.add(AlgDncBackend_DNC_PwAffineC_AffineMP.DISCO_PWAFFINEC_AFFINEMP);
 		
 		curves.add(AlgDncBackend_MPARTC_PwAffine.MPARTC_PWAFFINE);
-		//curves.add(AlgDncBackend_MPARTC_DISCO_Affine.MPARTC_PWAFFINEC_DISCO_AFFINEMP);
+		curves.add(AlgDncBackend_MPARTC_DISCO_Affine.MPARTC_PWAFFINEC_DISCO_AFFINEMP);
 		curves.add(AlgDncBackend_MPARTC_DISCO_PwAffine.MPARTC_PWAFFINEC_DISCO_CONPWAFFINEMP);
 
 		// Parameter configurations for single arrival bounding tests:
@@ -165,30 +162,6 @@ public class DncTestMethodSources {
 
 		return test_configurations;
 	}
-}
-
-enum AlgDncBackend_DNC_AffineC_PwAffineMP implements AlgDncBackend {
-	DISCO_AFFINEC_PWAFFINEMP;
-
-	@Override
-	public MinPlus getMinPlus() {
-		return MinPlus_Disco_ConPwAffine.MINPLUS_DISCO_CONPWAFFINE;
-	}
-
-	@Override
-	public Curve getCurveFactory() {
-		return Curve_Disco_Affine.getFactory();
-	}
-
-	@Override
-	public LinearSegment.Builder getLinearSegmentFactory() {
-		return LinearSegment_Disco.getBuilder();
-	}
-
-    @Override
-    public String toString() {
-         return assembleString(this.name(), MinPlus_Disco_ConPwAffine.MINPLUS_DISCO_CONPWAFFINE.name());
-    }
 }
 
 enum AlgDncBackend_DNC_PwAffineC_AffineMP implements AlgDncBackend {

--- a/java/org/networkcalculus/dnc/func_tests/DncTestResults.java
+++ b/java/org/networkcalculus/dnc/func_tests/DncTestResults.java
@@ -155,6 +155,8 @@ public abstract class DncTestResults {
 	}
 
 	public Num getEpsilon(Integer flowId, Analyses analysis, Set<ArrivalBoundMethod> ab_set, Multiplexing mux, NumBackend num_rep) {
+		return Num.getFactory(num_rep).create(5e-4);
+		/*
 		Map<Analyses, Map<Set<ArrivalBoundMethod>, Map<Multiplexing, Map<NumBackend, Num>>>> foi_maps = epsilon_map.get(flowId);
 		if(foi_maps == null || foi_maps.isEmpty()) {
 			return Num.getFactory(Calculator.getInstance().getNumBackend()).createZero();
@@ -185,6 +187,7 @@ public abstract class DncTestResults {
 		}
 		
 		return existing_epsilons.getOrDefault(num_rep, Num.getFactory(Calculator.getInstance().getNumBackend()).createZero());
+		*/
 	}
 
 	@Override

--- a/java/org/networkcalculus/dnc/func_tests/DncTestResults.java
+++ b/java/org/networkcalculus/dnc/func_tests/DncTestResults.java
@@ -155,8 +155,6 @@ public abstract class DncTestResults {
 	}
 
 	public Num getEpsilon(Integer flowId, Analyses analysis, Set<ArrivalBoundMethod> ab_set, Multiplexing mux, NumBackend num_rep) {
-		return Num.getFactory(num_rep).create(5e-4);
-		/*
 		Map<Analyses, Map<Set<ArrivalBoundMethod>, Map<Multiplexing, Map<NumBackend, Num>>>> foi_maps = epsilon_map.get(flowId);
 		if(foi_maps == null || foi_maps.isEmpty()) {
 			return Num.getFactory(Calculator.getInstance().getNumBackend()).createZero();
@@ -187,7 +185,6 @@ public abstract class DncTestResults {
 		}
 		
 		return existing_epsilons.getOrDefault(num_rep, Num.getFactory(Calculator.getInstance().getNumBackend()).createZero());
-		*/
 	}
 
 	@Override

--- a/java/org/networkcalculus/dnc/func_tests/FF_3S_1SC_2F_1AC_2P_Results.java
+++ b/java/org/networkcalculus/dnc/func_tests/FF_3S_1SC_2F_1AC_2P_Results.java
@@ -70,6 +70,7 @@ public class FF_3S_1SC_2F_1AC_2P_Results extends DncTestResults {
 			 * Real Double: Epsilon set to ignore
 			 * 		TFA delay ==> expected <128.33333333333334> but was <128.33333333333331>
 			 * 		TFA backlog ==> expected <633.3333333333334> but was <633.3333333333333>
+			 * 		TFA delay ==> expected <128.3333282470703> but was <128.33334350585938>
 			 * 
 			 * Real Single: Epsilon set to ignore
 			 * 		TFA delay ==> expected <128.33333> but was <128.33334>
@@ -83,7 +84,7 @@ public class FF_3S_1SC_2F_1AC_2P_Results extends DncTestResults {
 			 * 		TFA delay ==> expected <385 / 3> but was <5644159689250133 / 43980465111040>
 			 * 		TFA delay ==> expected <470 / 3> but was <220488731756680521 / 1407374883553280>
 			 */
-			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("3e-13"));
+			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("2e-13"));
 			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 
@@ -91,13 +92,17 @@ public class FF_3S_1SC_2F_1AC_2P_Results extends DncTestResults {
 			addEpsilon(1, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(1, Analyses.TFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 
-			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("6.75e-5"));
+			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("2e-5"));
 			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 
 			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("6.75e-5"));
 			addEpsilon(1, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 			addEpsilon(1, Analyses.TFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
+
+			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("6.75e-5"));
+			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
+			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 
 			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.RATIONAL_BIGINTEGER, rational_bigint_epsilon);
 			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.FIFO, NumBackend.RATIONAL_BIGINTEGER, rational_bigint_epsilon);
@@ -123,6 +128,7 @@ public class FF_3S_1SC_2F_1AC_2P_Results extends DncTestResults {
 			 * 		SFA delay ==> expected <87.77777777777777> but was <87.77777777777779>
 			 * 
 			 * Real Single: Epsilon set to ignore
+			 * 		SFA delay ==> expected:   <74.44444> but was  <74.444435>
 			 * 		SFA backlog ==> expected <455.55554> but was <455.55557>
 			 * 		SFA backlog ==> expected <455.5555419921875> but was <455.5555725097656>
 			 * 
@@ -137,6 +143,10 @@ public class FF_3S_1SC_2F_1AC_2P_Results extends DncTestResults {
 			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("2e-14"));
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+
+			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("25"));
+			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
+			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 
 			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("3.25e-5"));
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);

--- a/java/org/networkcalculus/dnc/func_tests/FF_4S_1SC_3F_1AC_3P_Results.java
+++ b/java/org/networkcalculus/dnc/func_tests/FF_4S_1SC_3F_1AC_3P_Results.java
@@ -72,6 +72,8 @@ public class FF_4S_1SC_3F_1AC_3P_Results extends DncTestResults {
 			 * 
 			 * Real Double: Epsilon set to ignore
 			 * 		TFA delay ==> expected <114.16666666666667> but was <114.16666666666666>
+			 * 		TFA backlog ==> expected <680.5555555555555> but was <680.5555555555557>
+			 * 		TFA delay ==> expected <133.05555555555554> but was <133.05555555555557>
 			 * 
 			 * Real Single: Epsilon set to ignore
 			 * 		TFA delay ==> expected <114.166664> but was <114.16667>
@@ -87,6 +89,13 @@ public class FF_4S_1SC_3F_1AC_3P_Results extends DncTestResults {
 			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("6e-14"));
 			addEpsilon(2, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(2, Analyses.TFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+
+			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("2e-13"));
+			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+
+			addEpsilon(1, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+			addEpsilon(1, Analyses.TFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 
 			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("3.25e-5"));
 			addEpsilon(2, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
@@ -122,6 +131,7 @@ public class FF_4S_1SC_3F_1AC_3P_Results extends DncTestResults {
 			 * Real Single: Epsilon set to ignore
 			 * 		SFA delay ==> expected <77.59259> but was <77.5926>
 			 * 		SFA delay ==> expected <341.66666> but was <341.6667>
+			 * 		SFA backlog ==> expected <404.629638671875> but was <404.62957763671875>
 			 * 
 			 * Rational BigInteger: Epsilon set to ignore
 			 * 		SFA delay ==> expected <875 / 9> but was <25655271314773333 / 263882790666240>
@@ -134,7 +144,7 @@ public class FF_4S_1SC_3F_1AC_3P_Results extends DncTestResults {
 			addEpsilon(2, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(2, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 
-			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("1e-5"));
+			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("6.25e-5"));
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 			

--- a/java/org/networkcalculus/dnc/func_tests/FF_4S_1SC_4F_1AC_4P_Results.java
+++ b/java/org/networkcalculus/dnc/func_tests/FF_4S_1SC_4F_1AC_4P_Results.java
@@ -157,6 +157,8 @@ public class FF_4S_1SC_4F_1AC_4P_Results extends DncTestResults {
 			 * 		TFA delay ==> expected <184.16666666666666> but was <184.16666666666669>
 			 * 		TFA backlog ==> expected <691.6666666666666> but was <691.6666666666667>
 			 * 		TFA delay ==> expected <466.6666666666667> but was <466.66666666666663>
+			 * 		TFA delay ==> expected <456.6666666666667> but was <456.66666666666663>
+			 * 		TFA delay ==> expected <460.8333333333333> but was <460.83333333333326>
 			 * 
 			 * Real Single: Epsilon set to ignore
 			 * 		TFA delay ==> expected <399.16666> but was <399.1667>
@@ -164,6 +166,8 @@ public class FF_4S_1SC_4F_1AC_4P_Results extends DncTestResults {
 			 * 		TFA delay ==> expected <184.1666717529297> but was <184.16665649414062>
 			 * 		TFA backlog ==> expected <691.6666870117188> but was <691.6666259765625>
 			 * 		TFA delay ==> expected <466.66666> but was <466.6667>
+			 * 		TFA delay ==> expected <456.66666> but was <456.6667>
+			 * 		TFA delay ==> expected <460.83334> but was <460.83337>
 			 * 
 			 * Rational BigInteger: Epsilon set to ignore
 			 * 		TFA delay ==> expected <1370 / 3> but was <80337649602833067 / 175921860444160>
@@ -183,6 +187,9 @@ public class FF_4S_1SC_4F_1AC_4P_Results extends DncTestResults {
 			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("7e-14"));
 			addEpsilon(3, Analyses.TFA, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(3, Analyses.TFA, ab_set_epsilon, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+			
+			addEpsilon(0, Analyses.TFA, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+			addEpsilon(0, Analyses.TFA, ab_set_epsilon, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 
 			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("4e-5"));
 			addEpsilon(1, Analyses.TFA, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
@@ -195,6 +202,10 @@ public class FF_4S_1SC_4F_1AC_4P_Results extends DncTestResults {
 			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("4e-5"));
 			addEpsilon(3, Analyses.TFA, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 			addEpsilon(3, Analyses.TFA, ab_set_epsilon, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
+
+			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("7e-5"));
+			addEpsilon(0, Analyses.TFA, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
+			addEpsilon(0, Analyses.TFA, ab_set_epsilon, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 
 			addEpsilon(0, Analyses.TFA, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.RATIONAL_BIGINTEGER, rational_bigint_epsilon);
 			addEpsilon(0, Analyses.TFA, ab_set_epsilon, Multiplexing.FIFO, NumBackend.RATIONAL_BIGINTEGER, rational_bigint_epsilon);
@@ -222,6 +233,7 @@ public class FF_4S_1SC_4F_1AC_4P_Results extends DncTestResults {
 			 * 		SFA delay ==> expected <90.27777777777777> but was <90.27777777777779>
 			 * 		SFA delay ==> expected <186.66666666666666> but was <186.66666666666669>
 			 * 		SFA backlog ==> expected <945.8333333333334> but was <945.8333333333333>
+			 * 		SFA backlog ==> expected <463.8888888888889> but was <463.88888888888886>
 			 * 
 			 * Real Single: Epsilon set to ignore
 			 * 		SFA backlog ==> expected <979.1667> but was <979.1666>
@@ -248,7 +260,7 @@ public class FF_4S_1SC_4F_1AC_4P_Results extends DncTestResults {
 			addEpsilon(1, Analyses.SFA, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(1, Analyses.SFA, ab_set_epsilon, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 
-			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("2e-14"));
+			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("1e-13"));
 			addEpsilon(2, Analyses.SFA, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(2, Analyses.SFA, ab_set_epsilon, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 
@@ -295,6 +307,10 @@ public class FF_4S_1SC_4F_1AC_4P_Results extends DncTestResults {
 			 * 		PMOO backlog ==> expected <885.4166666666666> but was <885.4166666666665>
 			 * 		PMOO delay ==> expected <190.83333333333334> but was <190.83333333333331>
 			 * 		PMOO backlog ==> expected <966.6666666666666> but was <966.6666666666665>
+			 * 		PMOO delay ==> expected <101.66666666666667> but was <101.66666666666666>
+			 * 		PMOO delay ==> expected <216.66666666666666> but was <216.66666666666669>
+			 * 		PMOO backlog ==> expected <1095.8333333333333> but was <1095.8333333333335>
+			 * 		PMOO backlog ==> expected <520.8333333333334> but was <520.8333333333333>
 			 * 
 			 * Real Single: Epsilon set to ignore
 			 * 		PMOO delay ==> expected <216.66667> but was <216.66666>
@@ -305,6 +321,8 @@ public class FF_4S_1SC_4F_1AC_4P_Results extends DncTestResults {
 			 * 		PMOO backlog ==> expected <885.4166870117188> but was <885.416748046875>
 			 * 		PMOO delay ==> expected <190.83333> but was <190.83334>
 			 * 		PMOO backlog ==> expected <966.6667> but was <966.6666>
+			 * 		PMOO delay ==> expected <101.666664> but was <101.66667>
+			 * 		PMOO backlog ==> expected <520.8333129882812> but was <520.8333740234375>
 			 * 
 			 * Rational BigInteger: Epsilon set to ignore
 			 * 		PMOO delay ==> expected <650 / 3> but was <19058201548117333 / 87960930222080>
@@ -319,6 +337,12 @@ public class FF_4S_1SC_4F_1AC_4P_Results extends DncTestResults {
 			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("1.25e-13"));
 			addEpsilon(3, Analyses.PMOO, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 
+			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("2e-13"));
+			addEpsilon(2, Analyses.PMOO, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+
+			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("3e-13"));
+			addEpsilon(0, Analyses.PMOO, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+
 			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("1.25e-4"));
 			addEpsilon(0, Analyses.PMOO, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 
@@ -327,6 +351,9 @@ public class FF_4S_1SC_4F_1AC_4P_Results extends DncTestResults {
 
 			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("1.25e-4"));
 			addEpsilon(3, Analyses.PMOO, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
+
+			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("6.25e-5"));
+			addEpsilon(2, Analyses.PMOO, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 
 			addEpsilon(0, Analyses.PMOO, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.RATIONAL_BIGINTEGER, rational_bigint_epsilon);
 			addEpsilon(1, Analyses.PMOO, ab_set_epsilon, Multiplexing.ARBITRARY, NumBackend.RATIONAL_BIGINTEGER, rational_bigint_epsilon);

--- a/java/org/networkcalculus/dnc/func_tests/TA_3S_1SC_3F_1AC_3P_Results.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_3S_1SC_3F_1AC_3P_Results.java
@@ -168,6 +168,7 @@ public class TA_3S_1SC_3F_1AC_3P_Results extends DncTestResults {
 			 * 		SFA backlog ==> expected <341.6666666666667> but was <341.66666666666663>
 			 * 		SFA delay ==> expected <52.03703703703704> but was <52.03703703703703>
 			 * 		SFA backlog ==> expected <483.3333333333333> but was <483.33333333333326>
+			 * 		SFA backlog ==> expected <258.3333333333333> but was <258.33333333333337>
 			 * 
 			 * Real Single: Epsilon set to ignore
 			 * 		SFA backlog ==> expected <341.66666> but was <341.6667>
@@ -175,6 +176,7 @@ public class TA_3S_1SC_3F_1AC_3P_Results extends DncTestResults {
 			 * 		SFA delay ==> expected <48.333332> but was <48.333336>
 			 * 		SFA backlog ==> expected <483.33334> but was <483.33337>
 			 * 		SFA backlog ==> expected <483.3333435058594> but was <483.3333740234375>
+			 * 		SFA backlog ==> expected <258.3333435058594> but was <258.33331298828125>
 			 * 
 			 * Rational BigInteger: Epsilon set to ignore
 			 * 		SFA backlog ==> expected <1025 / 3> but was <3005331782587733 / 8796093022208>
@@ -185,7 +187,7 @@ public class TA_3S_1SC_3F_1AC_3P_Results extends DncTestResults {
 			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			
-			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("1e-14"));
+			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("7e-14"));
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			
@@ -197,7 +199,7 @@ public class TA_3S_1SC_3F_1AC_3P_Results extends DncTestResults {
 			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 
-			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("4e-6"));
+			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("3.25e-5"));
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 

--- a/java/org/networkcalculus/dnc/func_tests/TA_4S_1SC_2F_1AC_2P_Results.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_4S_1SC_2F_1AC_2P_Results.java
@@ -134,6 +134,7 @@ public class TA_4S_1SC_2F_1AC_2P_Results extends DncTestResults {
 			 * 
 			 * Real Double: Epsilon set to ignore
 			 * 		TFA delay ==> expected <194.58333333333334> but was <194.58333333333331>
+			 * 		TFA backlog ==> expected <566.6666666666666> but was <566.6666666666667>
 			 * 
 			 * Real Single: Epsilon set to ignore
 			 * 		TFA delay ==> expected <194.58333> but was <194.58334>
@@ -143,7 +144,7 @@ public class TA_4S_1SC_2F_1AC_2P_Results extends DncTestResults {
 			 * Rational BigInteger: Epsilon set to ignore
 			 * 		TFA delay ==> expected <2335 / 12> but was <34231462011426133 / 175921860444160>
 			 */
-			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("3e-14"));
+			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("2e-13"));
 			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(0, Analyses.TFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 
@@ -162,10 +163,14 @@ public class TA_4S_1SC_2F_1AC_2P_Results extends DncTestResults {
 			 * 
 			 * Real Double: Epsilon set to ignore
 			 * 		SFA backlog ==> expected <408.3333333333333> but was <408.33333333333326>
+			 * 		SFA delay ==> expected <105.0> but was <105.00000000000001>
+			 * 		SFA backlog ==> expected <541.6666666666666> but was <541.6666666666667>
 			 * 
 			 * Real Single: Epsilon set to ignore
 			 * 		SFA backlog ==> expected <408.33334> but was <408.33337>
 			 * 		SFA backlog ==> expected <408.3333435058594> but was <408.3333740234375>
+			 * 		SFA delay ==> expected <105.0> but was <104.99999>
+			 * 		SFA backlog ==> expected <541.6666870117188> but was <541.6666259765625>
 			 * 
 			 * Rational BigInteger: Epsilon set to ignore
 			 * 		SFA backlog ==> expected <1625 / 3> but was <4764550387029333 / 8796093022208>
@@ -174,10 +179,18 @@ public class TA_4S_1SC_2F_1AC_2P_Results extends DncTestResults {
 			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("6e-14"));
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+		
+			real_double_epsilon = new RealDoublePrecision(Double.parseDouble("2e-13"));
+			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
+			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_DOUBLE_PRECISION, real_double_epsilon);
 
 			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("3.25e-5"));
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 			addEpsilon(1, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
+
+			real_single_epsilon = new RealSinglePrecision(Float.parseFloat("6.25e-5"));
+			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
+			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.REAL_SINGLE_PRECISION, real_single_epsilon);
 
 			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.ARBITRARY, NumBackend.RATIONAL_BIGINTEGER, rational_bigint_epsilon);
 			addEpsilon(0, Analyses.SFA, ab_set, Multiplexing.FIFO, NumBackend.RATIONAL_BIGINTEGER, rational_bigint_epsilon);


### PR DESCRIPTION
Now code, new epsilons. Also, cannot apply generic minplus operations to affine curves anymore because they do not necessarily adhere to the "max 2 segments" restriction.