### PR TITLE
Cleanups and Code Structure Improvements

### DIFF
--- a/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
+++ b/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
@@ -116,21 +116,21 @@ public class DncTestMethodSources {
 	}
 	
 	protected static Stream<Arguments> provideArbNonPmooArguments() {
-		Set<Set<ArrivalBoundMethod>> ab_sets_excl_pmoo = new HashSet<Set<ArrivalBoundMethod>>();
-		ab_sets_excl_pmoo.add(single_1);
-		ab_sets_excl_pmoo.add(single_2);
-		ab_sets_excl_pmoo.add(pair_1);
+		Set<Set<ArrivalBoundMethod>> ab_sets_non_pmoo = new HashSet<Set<ArrivalBoundMethod>>();
+		ab_sets_non_pmoo.add(single_1);
+		ab_sets_non_pmoo.add(single_2);
+		ab_sets_non_pmoo.add(pair_1);
 		
-		return createParameters(Collections.singleton(Multiplexing.FIFO), ab_sets_excl_pmoo, new HashSet<AlgDncBackend>())
+		return createParameters(Collections.singleton(Multiplexing.FIFO), ab_sets_non_pmoo, new HashSet<AlgDncBackend>())
 				.stream().map(Arguments::of);
 	}
 	
 	protected static Stream<Arguments> provideArbPmooArguments() {
-		Set<Set<ArrivalBoundMethod>> ab_sets_incl_pmoo = new HashSet<Set<ArrivalBoundMethod>>();
-		ab_sets_incl_pmoo.add(single_3);
-		ab_sets_incl_pmoo.add(pair_2);
-		ab_sets_incl_pmoo.add(pair_3);
-		ab_sets_incl_pmoo.add(triplet);
+		Set<Set<ArrivalBoundMethod>> ab_sets_pmoo = new HashSet<Set<ArrivalBoundMethod>>();
+		ab_sets_pmoo.add(single_3);
+		ab_sets_pmoo.add(pair_2);
+		ab_sets_pmoo.add(pair_3);
+		ab_sets_pmoo.add(triplet);
 		
 		return createParameters(Collections.singleton(Multiplexing.ARBITRARY), ab_sets, new HashSet<AlgDncBackend>())
 				.stream().map(Arguments::of);
@@ -164,30 +164,30 @@ public class DncTestMethodSources {
 		nums.add(NumBackend.RATIONAL_INTEGER);
 		nums.add(NumBackend.RATIONAL_BIGINTEGER);
 
-		Set<AlgDncBackend> curves = new HashSet<AlgDncBackend>();
-		curves.add(AlgDncBackend_DNC_ConPwAffine.DISCO_CONPWAFFINE);
-		curves.add(AlgDncBackend_DNC_Affine.DISCO_AFFINE);
+		Set<AlgDncBackend> alg_backends = new HashSet<AlgDncBackend>();
+		alg_backends.add(AlgDncBackend_DNC_ConPwAffine.DISCO_CONPWAFFINE);
+		alg_backends.add(AlgDncBackend_DNC_Affine.DISCO_AFFINE);
 
-		curves.add(AlgDncBackend_DNC_PwAffineC_Affine.DISCO_PWAFFINEC_AFFINEMP);
+		alg_backends.add(AlgDncBackend_DNC_PwAffineC_Affine.DISCO_PWAFFINEC_AFFINEMP);
 		
-		curves.add(AlgDncBackend_MPARTC_PwAffine.MPARTC_PWAFFINE);
-		curves.add(AlgDncBackend_MPARTC_DISCO_Affine.MPARTC_PWAFFINEC_DISCO_AFFINEMP);
-		curves.add(AlgDncBackend_MPARTC_DISCO_ConPwAffine.MPARTC_PWAFFINEC_DISCO_CONPWAFFINEMP);
+		alg_backends.add(AlgDncBackend_MPARTC_PwAffine.MPARTC_PWAFFINE);
+		alg_backends.add(AlgDncBackend_MPARTC_DISCO_Affine.MPARTC_PWAFFINEC_DISCO_AFFINEMP);
+		alg_backends.add(AlgDncBackend_MPARTC_DISCO_ConPwAffine.MPARTC_PWAFFINEC_DISCO_CONPWAFFINEMP);
 
 		// Parameter configurations for single arrival bounding tests:
 		// 		AB, convolve alternative ABs, global mux def, number class to use, curve class to use.
-		for (AlgDncBackend curve : curves) {
+		for (AlgDncBackend alg : alg_backends) {
 			for (NumBackend num : nums) {
 				for (Set<ArrivalBoundMethod> ab : ab_sets) {
 					for (Multiplexing mux : mux_disciplines) {
-						test_configurations.add(new DncTestConfig(ab, false, false, mux, false, num, curve));
-						test_configurations.add(new DncTestConfig(ab, false, false, mux, true, num, curve));
-						test_configurations.add(new DncTestConfig(ab, false, true, mux, false, num, curve));
-						test_configurations.add(new DncTestConfig(ab, false, true, mux, true, num, curve));
-						test_configurations.add(new DncTestConfig(ab, true, false, mux, false, num, curve));
-						test_configurations.add(new DncTestConfig(ab, true, false, mux, true, num, curve));
-						test_configurations.add(new DncTestConfig(ab, true, true, mux, false, num, curve));
-						test_configurations.add(new DncTestConfig(ab, true, true, mux, true, num, curve));
+						test_configurations.add(new DncTestConfig(ab, false, false, mux, false, num, alg));
+						test_configurations.add(new DncTestConfig(ab, false, false, mux, true, num, alg));
+						test_configurations.add(new DncTestConfig(ab, false, true, mux, false, num, alg));
+						test_configurations.add(new DncTestConfig(ab, false, true, mux, true, num, alg));
+						test_configurations.add(new DncTestConfig(ab, true, false, mux, false, num, alg));
+						test_configurations.add(new DncTestConfig(ab, true, false, mux, true, num, alg));
+						test_configurations.add(new DncTestConfig(ab, true, true, mux, false, num, alg));
+						test_configurations.add(new DncTestConfig(ab, true, true, mux, true, num, alg));
 					}
 				}
 			}

--- a/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
+++ b/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
@@ -49,6 +49,7 @@ import org.networkcalculus.dnc.bounds.Bounds;
 import org.networkcalculus.dnc.bounds.disco.BoundingCurves_Disco_ConPwAffine;
 import org.networkcalculus.dnc.bounds.disco.Bounds_Disco_PwAffine;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.curves.CurveUtils;
 import org.networkcalculus.dnc.curves.LinearSegment;
 import org.networkcalculus.dnc.curves.disco.LinearSegment_Disco;
@@ -216,7 +217,7 @@ enum AlgDncBackend_DNC_PwAffineC_Affine implements AlgDncBackend {
 	}
 
 	@Override
-	public Curve getCurveFactory() {
+	public CurveFactory_Affine getCurveFactory() {
 		return Curve_Disco_PwAffine.getFactory();
 	}
 

--- a/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
+++ b/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
@@ -49,8 +49,10 @@ import org.networkcalculus.dnc.bounds.Bounds;
 import org.networkcalculus.dnc.bounds.disco.BoundingCurves_Disco_ConPwAffine;
 import org.networkcalculus.dnc.bounds.disco.Bounds_Disco_PwAffine;
 import org.networkcalculus.dnc.curves.Curve;
+import org.networkcalculus.dnc.curves.CurveUtils;
 import org.networkcalculus.dnc.curves.LinearSegment;
 import org.networkcalculus.dnc.curves.disco.LinearSegment_Disco;
+import org.networkcalculus.dnc.curves.disco.pw_affine.CurveUtils_Disco_PwAffine;
 import org.networkcalculus.dnc.curves.disco.pw_affine.Curve_Disco_PwAffine;
 import org.networkcalculus.dnc.func_tests.AlgDncBackend_DNC_PwAffineC_Affine;
 import org.networkcalculus.dnc.func_tests.DncTestConfig;
@@ -193,6 +195,11 @@ enum AlgDncBackend_DNC_PwAffineC_Affine implements AlgDncBackend {
 	@Override
 	public Curve getCurveFactory() {
 		return Curve_Disco_PwAffine.getFactory();
+	}
+
+	@Override
+	public CurveUtils getCurveUtils() {
+		return CurveUtils_Disco_PwAffine.getInstance();
 	}
 
 	@Override

--- a/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
+++ b/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
@@ -48,7 +48,6 @@ import org.networkcalculus.dnc.bounds.BoundingCurves;
 import org.networkcalculus.dnc.bounds.Bounds;
 import org.networkcalculus.dnc.bounds.disco.BoundingCurves_Disco_ConPwAffine;
 import org.networkcalculus.dnc.bounds.disco.Bounds_Disco_PwAffine;
-import org.networkcalculus.dnc.curves.Curve;
 import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.curves.CurveUtils;
 import org.networkcalculus.dnc.curves.LinearSegment;

--- a/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
+++ b/java/org/networkcalculus/dnc/func_tests/DncTestMethodSources.java
@@ -109,30 +109,53 @@ public class DncTestMethodSources {
 	}
 
 	public static Stream<Arguments> provideAllArguments() {
-		return Stream.concat(provideArbArguments(), provideFifoArguments());
+		return Stream.concat(
+					Stream.concat(provideArbNonPmooArguments(), provideArbPmooArguments()),
+					provideFifoExclPmooArguments()
+				);
 	}
 	
-	protected static Stream<Arguments> provideArbArguments() {
-		return createParameters(Collections.singleton(Multiplexing.ARBITRARY), ab_sets).stream().map(Arguments::of);
-	}
-	
-	protected static Stream<Arguments> provideFifoArguments() {
-		Set<Set<ArrivalBoundMethod>> ab_sets_fifo = new HashSet<Set<ArrivalBoundMethod>>();
-		ab_sets_fifo.add(single_1);
-		ab_sets_fifo.add(single_2);
-		ab_sets_fifo.add(pair_1);
+	protected static Stream<Arguments> provideArbNonPmooArguments() {
+		Set<Set<ArrivalBoundMethod>> ab_sets_excl_pmoo = new HashSet<Set<ArrivalBoundMethod>>();
+		ab_sets_excl_pmoo.add(single_1);
+		ab_sets_excl_pmoo.add(single_2);
+		ab_sets_excl_pmoo.add(pair_1);
 		
-		return createParameters(Collections.singleton(Multiplexing.FIFO), ab_sets_fifo).stream().map(Arguments::of);
+		return createParameters(Collections.singleton(Multiplexing.FIFO), ab_sets_excl_pmoo, new HashSet<AlgDncBackend>())
+				.stream().map(Arguments::of);
+	}
+	
+	protected static Stream<Arguments> provideArbPmooArguments() {
+		Set<Set<ArrivalBoundMethod>> ab_sets_incl_pmoo = new HashSet<Set<ArrivalBoundMethod>>();
+		ab_sets_incl_pmoo.add(single_3);
+		ab_sets_incl_pmoo.add(pair_2);
+		ab_sets_incl_pmoo.add(pair_3);
+		ab_sets_incl_pmoo.add(triplet);
+		
+		return createParameters(Collections.singleton(Multiplexing.ARBITRARY), ab_sets, new HashSet<AlgDncBackend>())
+				.stream().map(Arguments::of);
+	}
+	
+	protected static Stream<Arguments> provideFifoExclPmooArguments() {
+		Set<Set<ArrivalBoundMethod>> ab_sets_excl_pmoo = new HashSet<Set<ArrivalBoundMethod>>();
+		ab_sets_excl_pmoo.add(single_1);
+		ab_sets_excl_pmoo.add(single_2);
+		ab_sets_excl_pmoo.add(pair_1);
+		
+		return createParameters(Collections.singleton(Multiplexing.FIFO), ab_sets_excl_pmoo, new HashSet<AlgDncBackend>())
+				.stream().map(Arguments::of);
 	}
 	
 	protected static Stream<Arguments> provideSinkTreeArguments() {
 		Set<Set<ArrivalBoundMethod>> ab_sets_sinktree = new HashSet<Set<ArrivalBoundMethod>>();
 		ab_sets_sinktree.add(sinktree);
 		
-		return createParameters(Collections.singleton(Multiplexing.ARBITRARY), ab_sets_sinktree).stream().map(Arguments::of);
+		return createParameters(Collections.singleton(Multiplexing.ARBITRARY), ab_sets_sinktree, new HashSet<AlgDncBackend>())
+				.stream().map(Arguments::of);
 	}
 
-	private static Set<DncTestConfig> createParameters(Set<Multiplexing> mux_disciplines, Set<Set<ArrivalBoundMethod>> ab_sets) {
+	private static Set<DncTestConfig> createParameters(Set<Multiplexing> mux_disciplines, 
+			Set<Set<ArrivalBoundMethod>> ab_sets, Set<AlgDncBackend> curves_excl) {
 		Set<DncTestConfig> test_configurations = new HashSet<DncTestConfig>();
 
 		Set<NumBackend> nums = new HashSet<NumBackend>();

--- a/java/org/networkcalculus/dnc/func_tests/FF_3S_1SC_2F_1AC_2P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/FF_3S_1SC_2F_1AC_2P_Test.java
@@ -68,7 +68,7 @@ public class FF_3S_1SC_2F_1AC_2P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -109,7 +109,7 @@ public class FF_3S_1SC_2F_1AC_2P_Test extends DncTest {
 	}
 	
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/FF_4S_1SC_3F_1AC_3P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/FF_4S_1SC_3F_1AC_3P_Test.java
@@ -69,7 +69,7 @@ public class FF_4S_1SC_3F_1AC_3P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -110,7 +110,7 @@ public class FF_4S_1SC_3F_1AC_3P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -151,7 +151,7 @@ public class FF_4S_1SC_3F_1AC_3P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f2_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/FF_4S_1SC_4F_1AC_4P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/FF_4S_1SC_4F_1AC_4P_Test.java
@@ -70,7 +70,7 @@ public class FF_4S_1SC_4F_1AC_4P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -111,7 +111,7 @@ public class FF_4S_1SC_4F_1AC_4P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -152,7 +152,7 @@ public class FF_4S_1SC_4F_1AC_4P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f2_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -193,7 +193,7 @@ public class FF_4S_1SC_4F_1AC_4P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f3_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/S_1SC_10F_10AC_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/S_1SC_10F_10AC_Test.java
@@ -68,7 +68,7 @@ public class S_1SC_10F_10AC_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -101,7 +101,7 @@ public class S_1SC_10F_10AC_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f6_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/S_1SC_1F_1AC_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/S_1SC_1F_1AC_Test.java
@@ -67,7 +67,7 @@ public class S_1SC_1F_1AC_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/S_1SC_2F_1AC_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/S_1SC_2F_1AC_Test.java
@@ -68,7 +68,7 @@ public class S_1SC_2F_1AC_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -101,7 +101,7 @@ public class S_1SC_2F_1AC_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/S_1SC_2F_2AC_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/S_1SC_2F_2AC_Test.java
@@ -68,7 +68,7 @@ public class S_1SC_2F_2AC_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -101,7 +101,7 @@ public class S_1SC_2F_2AC_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TA_2S_1SC_1F_1AC_1P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_2S_1SC_1F_1AC_1P_Test.java
@@ -67,7 +67,7 @@ public class TA_2S_1SC_1F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TA_2S_1SC_2F_1AC_1P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_2S_1SC_2F_1AC_1P_Test.java
@@ -68,7 +68,7 @@ public class TA_2S_1SC_2F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -101,7 +101,7 @@ public class TA_2S_1SC_2F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TA_2S_1SC_2F_1AC_2P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_2S_1SC_2F_1AC_2P_Test.java
@@ -68,7 +68,7 @@ public class TA_2S_1SC_2F_1AC_2P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -101,7 +101,7 @@ public class TA_2S_1SC_2F_1AC_2P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TA_2S_1SC_4F_1AC_1P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_2S_1SC_4F_1AC_1P_Test.java
@@ -70,7 +70,7 @@ public class TA_2S_1SC_4F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -103,7 +103,7 @@ public class TA_2S_1SC_4F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -136,7 +136,7 @@ public class TA_2S_1SC_4F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f2_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -169,7 +169,7 @@ public class TA_2S_1SC_4F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f3_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TA_2S_2SC_1F_1AC_1P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_2S_2SC_1F_1AC_1P_Test.java
@@ -67,7 +67,7 @@ public class TA_2S_2SC_1F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TA_2S_2SC_2F_1AC_1P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_2S_2SC_2F_1AC_1P_Test.java
@@ -68,7 +68,7 @@ public class TA_2S_2SC_2F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -101,7 +101,7 @@ public class TA_2S_2SC_2F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TA_3S_1SC_2F_1AC_1P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_3S_1SC_2F_1AC_1P_Test.java
@@ -68,7 +68,7 @@ public class TA_3S_1SC_2F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -101,7 +101,7 @@ public class TA_3S_1SC_2F_1AC_1P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TA_3S_1SC_3F_1AC_3P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_3S_1SC_3F_1AC_3P_Test.java
@@ -69,7 +69,7 @@ public class TA_3S_1SC_3F_1AC_3P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -102,7 +102,7 @@ public class TA_3S_1SC_3F_1AC_3P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -143,7 +143,7 @@ public class TA_3S_1SC_3F_1AC_3P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f2_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TA_4S_1SC_2F_1AC_2P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TA_4S_1SC_2F_1AC_2P_Test.java
@@ -68,7 +68,7 @@ public class TA_4S_1SC_2F_1AC_2P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -109,7 +109,7 @@ public class TA_4S_1SC_2F_1AC_2P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TR_3S_1SC_2F_1AC_2P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TR_3S_1SC_2F_1AC_2P_Test.java
@@ -68,7 +68,7 @@ public class TR_3S_1SC_2F_1AC_2P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -101,7 +101,7 @@ public class TR_3S_1SC_2F_1AC_2P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());

--- a/java/org/networkcalculus/dnc/func_tests/TR_7S_1SC_3F_1AC_3P_Test.java
+++ b/java/org/networkcalculus/dnc/func_tests/TR_7S_1SC_3F_1AC_3P_Test.java
@@ -69,7 +69,7 @@ public class TR_7S_1SC_3F_1AC_3P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f0_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -102,7 +102,7 @@ public class TR_7S_1SC_3F_1AC_3P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f1_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());
@@ -135,7 +135,7 @@ public class TR_7S_1SC_3F_1AC_3P_Test extends DncTest {
 	}
 
 	@ParameterizedTest(name = "[{arguments}]")
-	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbArguments")
+	@MethodSource("org.networkcalculus.dnc.func_tests.DncTestMethodSources#provideArbPmooArguments")
 	public void f2_pmoo_arbMux(DncTestConfig test_config) {
 		initializeTest(test_config);
 		setMux(network.getServers());


### PR DESCRIPTION
See PR NetCal/DNC#93

The additions make changes needed to break the assumption that all curve backends will work with the same static util methods -- or, put differently, that all curve backends will implement the DNC interface. Ultimately, this is a step towards wrapping the RTC MPA toolbox and using it as a backend for our analyses without duplicating curve util code (see NetCal/DNCext_MPARTC#14 and NetCal/DNC#86).